### PR TITLE
Enable Zsh syntax highlighting

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,8 +13,10 @@ sh -c "$(wget -O- https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools
 
 git clone --depth=1 https://github.com/zsh-users/zsh-autosuggestions ~/.zsh/zsh-autosuggestions
 git clone --depth=1 https://github.com/zsh-users/zsh-history-substring-search.git ~/.zsh/zsh-history-substring-search
+git clone --depth=1 https://github.com/zsh-users/zsh-syntax-highlighting.git ~/.zsh/zsh-syntax-highlighting
 echo 'source ~/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh' >> ~/.zshrc
 echo 'source ~/.zsh/zsh-history-substring-search/zsh-history-substring-search.zsh' >> ~/.zshrc
+echo 'source ~/.zsh/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh' >> ~/.zshrc
 #sed -i 's/robbyrussell/avit/g' ~/.zshrc
 sed -i 's/robbyrussell/bira/g' ~/.zshrc
 


### PR DESCRIPTION
Enable Zsh syntax highlighting (in addition to Zsh autosuggestions and Zsh history substring search) by cloning `zsh-user/zsh-syntax-highlighting` and sourcing its Zsh script in `install.sh`.